### PR TITLE
[Kabocha -> develop]  플레이어 인디케이터 버그 수정, RaptorBig, robuwa 인디케이터 수정

### DIFF
--- a/Assets/Script/Entity/Enemy/Raptor/RaptorBig.cs
+++ b/Assets/Script/Entity/Enemy/Raptor/RaptorBig.cs
@@ -5,8 +5,10 @@ using DG.Tweening;
 using Sophia.Composite;
 using NUnit.Framework;
 using UnityEngine.AI;
+using UnityEngine.UI;
 using System.Linq;
 using Sophia.Instantiates;
+using HUDIndicator;
 
 namespace Sophia.Entitys
 {
@@ -26,6 +28,7 @@ namespace Sophia.Entitys
         List<RaptorSmall> raptorSmallList;
         private float howlingCoolTime = 5f;
         Vector3 EscapePosition;
+        public IndicatorOffScreen indicatorOffScreen;
 
         #endregion
         protected override void Awake()
@@ -308,7 +311,8 @@ namespace Sophia.Entitys
         void Howl_Enter()
         {
             Debug.Log("Howl_Enter");
-
+            indicatorOffScreen.style.color = Color.red;
+            indicatorOffScreen.arrowStyle.color = Color.red;
             _nav.SetDestination(transform.position);
             _nav.isStopped = true;
             transform.DOLookAt(_objectiveEntity.transform.position, TurnSpeed);
@@ -326,6 +330,8 @@ namespace Sophia.Entitys
         void Howl_Exit()
         {
             GetModelManager().GetAnimator().SetBool("IsHowlEnd", false);
+            indicatorOffScreen.style.color = Color.yellow;
+            indicatorOffScreen.arrowStyle.color = Color.yellow;
 
             if (!howlingTimer.GetIsReadyToUse())
                 return;

--- a/Assets/Script/Entity/Enemy/RobUwa/Robuwa.cs
+++ b/Assets/Script/Entity/Enemy/RobUwa/Robuwa.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using MonsterLove.StateMachine;
 using UnityEngine.AI;
+using UnityEngine.UI;
 using DG.Tweening;
 using Sophia.Composite;
 using Sophia.DataSystem.Referer;
@@ -13,6 +14,8 @@ using Sophia_Carriers;
 using UnityEngine.Rendering;
 using FMODPlus;
 using Sophia.AI;
+using HUDIndicator;
+
 
 namespace Sophia.Entitys
 {
@@ -25,6 +28,7 @@ namespace Sophia.Entitys
         #region Public
         public int AttackRange;
         public int TurnSpeed;   //Stat으로 관리 가능성
+        public IndicatorOffScreen indicatorOffScreen;
         #endregion
 
         #region Private
@@ -311,7 +315,6 @@ namespace Sophia.Entitys
         void Threat_Enter()
         {
             //Debug.Log("Threat Enter");
-
             if (!isMovable) return;
             transform.DOKill();
             recognize.CurrentViewRadius *= 3;
@@ -438,7 +441,8 @@ namespace Sophia.Entitys
         void Attack_Enter()
         {
             //Debug.Log("Attack_Enter");
-
+            indicatorOffScreen.style.color = Color.red;
+            indicatorOffScreen.arrowStyle.color = Color.red;
 
             if (!isMovable) return;
             nav.SetDestination(transform.position);
@@ -453,12 +457,16 @@ namespace Sophia.Entitys
         {
             if (this.GetModelManager().GetAnimator().GetCurrentAnimatorStateInfo(0).normalizedTime >= 0.9f)
             {
+                indicatorOffScreen.style.color = Color.yellow;
+                indicatorOffScreen.arrowStyle.color = Color.yellow;
                 fsm.ChangeState(States.Idle);
             }
         }
 
         void Attack_Exit()
         {
+            indicatorOffScreen.style.color = Color.yellow;
+            indicatorOffScreen.arrowStyle.color = Color.yellow;
             ResetAnimParam();
         }
 

--- a/Assets/Script/_NewFeature/Entity/SkillIndicator.cs
+++ b/Assets/Script/_NewFeature/Entity/SkillIndicator.cs
@@ -76,6 +76,8 @@ namespace Sophia.Entitys
             {
                 currentIndicator = circleIndicator;
             }
+            else
+                IsIndicate = false;
         }
         private void turning()
         {   


### PR DESCRIPTION
1. 플레이어 인디케이터 버그 수정
- 모든 스킬에 대해 인디케이터가 띄워지는 버그를 수정하여 일부 인디케이터가 필요한 스킬에서만 작동되도록 수정

2. RaptorBig, robuwa 인디케이터 수정
- 기존의 raptorsmall, mollu처럼 특정 상태일때 인디케이터의 색상이 변경되도록 수정함