### PR TITLE
[kabocha -> develop] 스킵바 엘더원 영상 관련 버그 수정

### DIFF
--- a/Assets/Script/Screen/UI/VideoController.cs
+++ b/Assets/Script/Screen/UI/VideoController.cs
@@ -119,6 +119,8 @@ public class VideoController : MonoBehaviour
                 case E_VIDEO_NAME.ElderOne:
                     InGameScreenUI.Instance._bossHealthBar.SetActive(true);
                     InGameScreenUI.Instance._fadeUI.FadePanelOff();
+                    isVideoStart = false;
+                    skipCanvas.enabled = false;
                     commandStarter.SendCommand();
                     bossStateStarter.SendCommand();
                     break; 

--- a/Assets/UserData.json
+++ b/Assets/UserData.json
@@ -1,9 +1,9 @@
 {
   "IsNewFile": true,
-  "IsTutorial": false,
+  "IsTutorial": true,
   "CurrentChapterNum": 1,
   "CutSceneSaveData": {
-    "IsSkipStory": true
+    "IsSkipStory": false
   },
   "ChapterClearSaveData": {
     "IsChapter1Clear": false

--- a/fmod_editor.log
+++ b/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 00000251F90A5898 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 00000210715688C8 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.
@@ -22,3 +22,10 @@
 [LOG] PlaybackSystem::acquireMasterBus         : Setting master channel group format to 3
 [LOG] Manager::readBank                        : fileversion = 142, compatVersion = 140 (oldest = 44, newest = 142)
 [LOG] Manager::readBank                        : fileversion = 142, compatVersion = 140 (oldest = 44, newest = 142)
+[LOG] Thread::callback                         : FMOD Studio bank load thread finished.
+[LOG] Thread::callback                         : FMOD Studio sample load thread finished.
+[LOG] LiveUpdate::release                      : 
+[LOG] LiveUpdate::reset                        : Reset connection (reason Disconnected)
+[LOG] Thread::callback                         : FMOD stream thread finished.
+[LOG] Thread::callback                         : FMOD mixer thread finished.
+[LOG] SystemI::close                           : Closed.


### PR DESCRIPTION
1. 엘더원 보스 비디오 영상 노스킵 시 스킵바가 계속해서 뜨는 버그 수정